### PR TITLE
Add configurable elasticsearch port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY docker-entrypoint.sh /
 ENV INTERVAL_IN_HOURS=24
 ENV OLDER_THAN_IN_DAYS="20"
 ENV ELASTICSEARCH_HOST=elasticsearch
+ENV ELASTICSEARCH_TCP_PORT=9200
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,7 +9,7 @@ fi
 
 # Step down via gosu  
 if [ "$1" = 'curator' ]; then
-	exec gosu curator bash -c "while true; do curator --host $ELASTICSEARCH_HOST delete indices --older-than $OLDER_THAN_IN_DAYS --time-unit=days --timestring '%Y.%m.%d'; set -e; sleep $(( 60*60*INTERVAL_IN_HOURS )); set +e; done"
+	exec gosu curator bash -c "while true; do curator --host $ELASTICSEARCH_HOST --port $ELASTICSEARCH_TCP_PORT delete indices --older-than $OLDER_THAN_IN_DAYS --time-unit=days --timestring '%Y.%m.%d'; set -e; sleep $(( 60*60*INTERVAL_IN_HOURS )); set +e; done"
 fi
 
 # As argument is not related to curator,

--- a/readme.md
+++ b/readme.md
@@ -2,12 +2,16 @@
 
 This only job executed by the docker built from this repository is to clean the elastic search logstash history leaving only a configurable amount of days worth of logging in the system. The job runs in the specified interval.
 
-It can be run as follows:
+### Usage
 
 	docker run -d -e INTERVAL_IN_HOURS=24 -e OLDER_THAN_IN_DAYS="10" --link es1:elasticsearch visity/elasticsearch-curator
-	
+
 where **es1** is the name of the elasticsearch container and
 
 * **INTERVAL\_IN\_HOURS**: The amount of time between two curator runs
 * **OLDER\_THAN\_IN\_DAYS**: Indicates all logs with a date exceeding this age can be deleted.
 
+### Elasticsearch configuration
+
+* **ELASTICSEARCH_HOST**: The host where elasticsearch is running (defaults to _elasticsearch_)
+* **ELASTICSEARCH_TCP_PORT**: The port where elasticsearch is listening (defaults to _9200_)


### PR DESCRIPTION
This PR adds an environment variable to configure an alternate elasticsearch port (for example, AWS elasticsearch).

I was forced to choose the variable `ELASTICSEARCH_TCP_PORT` instead of `ELASTICSEARCH_PORT` (which would make more sense), because _Docker_ already exposes that variable when linking a container, albeit unusable to us since it exposes `tcp://elasticsearch:9200`.

Another alternative would be to parse the variable that docker exposes (which contains `tcp://elasticsearch:9200`) and retrieve the port from there. That approach isn't very useful for users who are running this container using _extra_hosts_, for example:

``` sh
docker run --add-host "elasticsearch:<ip>" visity/elasticsearch-curator
```
