### PR TITLE
Add a variable to provide a list of masters and update readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY docker-entrypoint.sh /
 ENV INTERVAL_IN_HOURS=24
 ENV OLDER_THAN_IN_DAYS="20"
 ENV ELASTICSEARCH_HOST=elasticsearch
+ENV ELASTICSEARCH_PORT=9200
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN arch="$(dpkg --print-architecture)" \
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r curator && useradd -r -g curator curator
 
-RUN pip install elasticsearch-curator==3.4.0
+RUN pip install elasticsearch-curator==3.5.1
 
 COPY docker-entrypoint.sh /
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -25,7 +25,7 @@ fi
 
 # Step down via gosu  
 if [ "$1" = 'curator' ]; then
-	exec gosu curator bash -c "while true; do curator --host $ELASTICSEARCH_HOST delete indices --older-than $OLDER_THAN_IN_DAYS --time-unit=days --timestring '%Y.%m.%d'; set -e; sleep $(( 60*60*INTERVAL_IN_HOURS )); set +e; done"
+	exec gosu curator bash -c "while true; do curator --host $ELASTICSEARCH_HOST --port $ELASTICSEARCH_PORT delete indices --older-than $OLDER_THAN_IN_DAYS --time-unit=days --timestring '%Y.%m.%d'; set -e; sleep $(( 60*60*INTERVAL_IN_HOURS )); set +e; done"
 fi
 
 # As argument is not related to curator,

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,6 +7,22 @@ if [ "${1:0:1}" = '-' ]; then
 	set -- curator "$@"
 fi
 
+## Find out who is the master
+if [[ ${ELASTICSEARCH_MASTERS} ]]
+then
+  echo "Finding elasticsearch master from: $ELASTICSEARCH_MASTERS"
+  for master in ${ELASTICSEARCH_MASTERS//,/ }
+  do
+    response=$(wget -qO- http://${master}:9200/_cat/master)
+    if [ "$?" -eq 0 ]
+    then
+      ELASTICSEARCH_URL=http://$(echo $response | awk '{printf $NF}'):9200
+      echo "Master found: $ELASTICSEARCH_URL"
+      break
+    fi
+  done
+fi
+
 # Step down via gosu  
 if [ "$1" = 'curator' ]; then
 	exec gosu curator bash -c "while true; do curator --host $ELASTICSEARCH_HOST delete indices --older-than $OLDER_THAN_IN_DAYS --time-unit=days --timestring '%Y.%m.%d'; set -e; sleep $(( 60*60*INTERVAL_IN_HOURS )); set +e; done"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -16,7 +16,7 @@ then
     response=$(wget -qO- http://${master}:9200/_cat/master)
     if [ "$?" -eq 0 ]
     then
-      ELASTICSEARCH_HOST=http://$(echo $response | awk '{printf $NF}'):9200
+      ELASTICSEARCH_HOST=$(echo $response | awk '{printf $NF}')
       echo "Master found: $ELASTICSEARCH_HOST"
       break
     fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -16,8 +16,8 @@ then
     response=$(wget -qO- http://${master}:9200/_cat/master)
     if [ "$?" -eq 0 ]
     then
-      ELASTICSEARCH_URL=http://$(echo $response | awk '{printf $NF}'):9200
-      echo "Master found: $ELASTICSEARCH_URL"
+      ELASTICSEARCH_HOST=http://$(echo $response | awk '{printf $NF}'):9200
+      echo "Master found: $ELASTICSEARCH_HOST"
       break
     fi
   done

--- a/readme.md
+++ b/readme.md
@@ -4,10 +4,10 @@ This only job executed by the docker built from this repository is to clean the 
 
 It can be run as follows:
 
-	docker run -d -e INTERVAL_IN_HOURS=24 -e OLDER_THAN_IN_DAYS="10" --link es1:elasticsearch visity/elasticsearch-curator
+	docker run -d -e INTERVAL_IN_HOURS=24 -e OLDER_THAN_IN_DAYS="10" -e ELASTICSEARCH_HOST="localhost:9200" visity/elasticsearch-curator
 	
-where **es1** is the name of the elasticsearch container and
-
 * **INTERVAL\_IN\_HOURS**: The amount of time between two curator runs
 * **OLDER\_THAN\_IN\_DAYS**: Indicates all logs with a date exceeding this age can be deleted.
+* **ELASTICSEARCH\_HOST**: Points to the elasticsearch master url
+* **ELASTICSEARCH\_MASTERS**: Optionally, other than ELASTICSEARCH\_HOST, a list of hosts can be provided here and the master will be chosen amongst them
 

--- a/readme.md
+++ b/readme.md
@@ -10,4 +10,5 @@ It can be run as follows:
 * **OLDER\_THAN\_IN\_DAYS**: Indicates all logs with a date exceeding this age can be deleted.
 * **ELASTICSEARCH\_HOST**: Points to the elasticsearch master url
 * **ELASTICSEARCH\_MASTERS**: Optionally, other than ELASTICSEARCH\_HOST, a list of hosts can be provided here and the master will be chosen amongst them
+* **ELASTICSEARCH\_PORT**: Port to access elasticsearch. It defaults to 9200
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ This only job executed by the docker built from this repository is to clean the 
 
 It can be run as follows:
 
-	docker run -d -e INTERVAL_IN_HOURS=24 -e OLDER_THAN_IN_DAYS="10" -e ELASTICSEARCH_HOST="localhost:9200" visity/elasticsearch-curator
+	docker run -d -e INTERVAL_IN_HOURS=24 -e OLDER_THAN_IN_DAYS="10" -e ELASTICSEARCH_HOST="localhost" visity/elasticsearch-curator
 	
 * **INTERVAL\_IN\_HOURS**: The amount of time between two curator runs
 * **OLDER\_THAN\_IN\_DAYS**: Indicates all logs with a date exceeding this age can be deleted.


### PR DESCRIPTION
The readme did not match what the code did about --link. 

An optional (instead of) variable ELASTICSEARCH_MASTERS makes it possible to provide a list of hosts and the current running master will be chosen amongst the list